### PR TITLE
Fix #2 - Fix default return value

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,12 +12,12 @@ var cyan = require('ansi-cyan');
 
 function Confirm(/*question, answers, rl*/) {
   Prompt.apply(this, arguments);
-  var defaultValue = true;
+  this.defaultValue = true
 
   if (typeof this.question.default === 'boolean') {
-    defaultValue = this.question.default;
+    this.defaultValue = this.question.default;
   }
-  this.question.default = defaultValue ? 'Y/n' : 'y/N';
+  this.question.default = this.defaultValue ? 'Y/n' : 'y/N';
   return this;
 }
 
@@ -56,7 +56,7 @@ Confirm.prototype.onSubmit = function(input) {
  */
 
 Confirm.prototype.getAnswer = function(input) {
-  return !!(isString(input) ? isTrue(input) : this.question.default);
+  return isString(input) ? isTrue(input) : this.defaultValue
 };
 
 /**
@@ -82,7 +82,7 @@ function isTrue(str) {
  */
 
 function isString(val) {
-  return val && typeof val === 'string';
+  return typeof val === 'string' && val.length > 0
 }
 
 /**


### PR DESCRIPTION
So what I did :
- the `var defaultValue` was changed to `this.defaultValue` so that it can be access. I just need confirmation that it makes sense and won't screw up: should I keep it like this **or** should I turn it into `this.question.defaultValue`. It might make more sense?
- I change the `isString()` function so that it checks for the type of the parameters and that it's not empty
- I remove the double negation `!!` in `getAnswer()` since it's not needed anymore (`isString()` now returns a boolean).

Seems good to you?
